### PR TITLE
Fix example to use SdFat.

### DIFF
--- a/examples/SimpleAudioPlayerZero/SimpleAudioPlayerZero.ino
+++ b/examples/SimpleAudioPlayerZero/SimpleAudioPlayerZero.ino
@@ -6,6 +6,7 @@
  Hardware required :
  * Arduino shield with a SD card on CS4
  * A sound file named "test.wav" in the root directory of the SD card
+   The file should be WAVE audio, Microsoft PCM, 16 bit, mono 88200 Hz
  * An audio amplifier to connect to the DAC0 and ground
  * A speaker to connect to the audio amplifier
 
@@ -20,9 +21,10 @@
 
 */
 
-#include <SD.h>
-#include <SPI.h>
+#include <SdFat.h>
 #include <AudioZero.h>
+
+SdFat SD;
 
 void setup()
 {
@@ -45,7 +47,7 @@ void loop()
   int count = 0;
 
   // open wave file from sdcard
-  File myFile = SD.open("test.wav");
+  File myFile = SD.open("test.wav", FILE_READ);
   if (!myFile) {
     // if the file didn't open, print an error and stop
     Serial.println("error opening test.wav");
@@ -55,7 +57,7 @@ void loop()
   AudioZero.prepare(myFile);
 
   Serial.print("Playing");
-  AudioZero.play(myFile);
+  AudioZero.play();
 
   Serial.println("End of file. Thank you for listening!");
   AudioZero.end();


### PR DESCRIPTION
Hi, here's a fix to use SdFat instead of SD in the example.

Thanks for your fixes, much appreciated that the speaker actually goes quiet after playing.